### PR TITLE
Use context manager for image opening in palette extraction

### DIFF
--- a/utils/color_utils.py
+++ b/utils/color_utils.py
@@ -5,7 +5,8 @@ def quantize_color(r, g, b, step=10):
     return tuple(min(max(round(c / step) * step, 0), 255) for c in (r, g, b))
 
 def extract_palette(image_path, num_colors=32, step=10):
-    image = Image.open(image_path).convert('RGBA')
+    with Image.open(image_path) as img:
+        image = img.convert('RGBA')
     pixels = list(image.getdata())
     filtered_pixels = [
         quantize_color(r, g, b, step)


### PR DESCRIPTION
## Summary
- open images with a context manager in `extract_palette` to ensure proper file handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6895528c08788328a3711b05abee7606